### PR TITLE
Add optional end-effector_pose to HardwareState.

### DIFF
--- a/examples/cartesian_pose_robot.py
+++ b/examples/cartesian_pose_robot.py
@@ -52,9 +52,6 @@ class MyCartesianPoseRobot(CartesianPoseRobot):
     def get_hardware_state(self) -> Optional[HardwareState]:
         state = HardwareState(
             joint_positions=np.copy(self.__joint_positions),
-            joint_speeds=None,
-            raw_wrench=None,
-            joint_temperatures=None
         )
         LOG.debug("State: %s", state)
         return state

--- a/examples/cartesian_velocity_robot.py
+++ b/examples/cartesian_velocity_robot.py
@@ -52,11 +52,8 @@ class MyCartesianVelocityRobot(CartesianVelocityRobot):
     def get_hardware_state(self) -> Optional[HardwareState]:
         state = HardwareState(
             joint_positions=np.copy(self.__joint_positions),
-            joint_speeds=None,
-            raw_wrench=None,
-            joint_temperatures=None
         )
-        LOG.debug("Hardware state: %s", state)
+        LOG.debug("State: %s", state)
         return state
 
     def clear_cached_hardware_state(self) -> None:

--- a/examples/joint_position_robot.py
+++ b/examples/joint_position_robot.py
@@ -50,12 +50,8 @@ class MyJointPositionRobot(JointPositionRobot):
         self.__ready_for_control = False
 
     def get_hardware_state(self) -> Optional[HardwareState]:
-        joint_positions = np.copy(self.__joint_positions)
         state = HardwareState(
-            joint_positions=joint_positions,
-            joint_speeds=None,
-            joint_temperatures=None,
-            raw_wrench=None,
+            joint_positions=np.copy(self.__joint_positions),
         )
         LOG.debug("State: %s", state)
         return state

--- a/examples/joint_speed_robot.py
+++ b/examples/joint_speed_robot.py
@@ -50,12 +50,8 @@ class MyJointSpeedRobot(JointSpeedRobot):
         self.__ready_for_control = False
 
     def get_hardware_state(self) -> Optional[HardwareState]:
-        joint_positions = np.copy(self.__joint_positions)
         state = HardwareState(
-            joint_positions=joint_positions,
-            joint_speeds=None,
-            joint_temperatures=None,
-            raw_wrench=None,
+            joint_positions=np.copy(self.__joint_positions),
         )
         LOG.debug("State: %s", state)
         return state

--- a/micropsi_integration_sdk/robot_sdk.py
+++ b/micropsi_integration_sdk/robot_sdk.py
@@ -9,7 +9,9 @@ HardwareState = namedtuple("HardwareState", (
     "joint_speeds",
     "joint_temperatures",
     "raw_wrench",
+    "end_effector_pose",
 ))
+HardwareState.__new__.__defaults__ = (None,) * len(HardwareState._fields)
 
 
 class RobotInterface(ABC):


### PR DESCRIPTION
Allows mirai to bypass the call to forward_kinematics on supporting
systems.