### PR TITLE
Add a pipeline to get internal FT support

### DIFF
--- a/micropsi_integration_sdk/robot_sdk.py
+++ b/micropsi_integration_sdk/robot_sdk.py
@@ -274,7 +274,8 @@ class RobotInterface(ABC):
         """
         raise NotImplementedError
 
-    def has_internal_ft_sensor(self) -> bool:
+    @staticmethod
+    def has_internal_ft_sensor() -> bool:
         """
         Optional, override as appropriate.
 


### PR DESCRIPTION
This PR is part of MPD-2397.

It adds a getter method for SDK robots to state for their internal FT sensor support. This then is collected under the robot_interface_collector to be accessed by mirai_api later.

It is tested through Gazebo robot with internal FT support. 