### PR TITLE
Add method to set wait for receive timeout

### DIFF
--- a/micropsi_integration_sdk/robot_sdk.py
+++ b/micropsi_integration_sdk/robot_sdk.py
@@ -275,6 +275,16 @@ class RobotInterface(ABC):
         raise NotImplementedError
 
     @staticmethod
+    def get_wait_for_receive_timeout() -> float:
+        """
+        Optional, override as appropriate.
+
+        Return how long the mirai runtime should wait for receiving hardware state readings from the
+        robot.
+        """
+        return 1.
+        
+    @staticmethod
     def has_internal_ft_sensor() -> bool:
         """
         Optional, override as appropriate.


### PR DESCRIPTION
Add a static method to allow a robot interface to set `wait_for_receive()` 's default timeout value of 1 second. This method preserves backwards compatibility by returning the previously set 1 second timeout value by default, in case it is not implemented in the robot interface.

The default `wait_for_receive()`'s timeout value of 1 second caused issues on slower machines with the Gazebo robot interface, since its `connect()` method was taking more than the 1 second timeout to connect to ROS websocket, and thus the simulated robot, causing `Error: Failed to start robot control thread.` to be thrown.

This answers to ticket `MPD-2347`.