### PR TITLE
Update slowdown_steps default value

### DIFF
--- a/micropsi_integration_sdk/robot_sdk.py
+++ b/micropsi_integration_sdk/robot_sdk.py
@@ -283,7 +283,7 @@ class RobotInterface(ABC):
         robot.
         """
         return 1.
-        
+
     @staticmethod
     def has_internal_ft_sensor() -> bool:
         """
@@ -323,7 +323,7 @@ class RobotInterface(ABC):
         }
 
     @staticmethod
-    def get_slowdown_steps() -> int:
+    def get_slowdown_steps_in_seconds() -> float:
         """
         Optional, override as appropriate.
 
@@ -332,9 +332,12 @@ class RobotInterface(ABC):
         This is to ensure a smooth approach without overshooting the goal position.
 
         Slowdown_steps needs to be adjusted according to a specific robot controller (based on its
-        acceleration and decelaration values). The default value is set to be 8.
+        acceleration and decelaration values). Since the actual step length depends on the stepping
+        frequency that can be adjusted later, the value is exposed in seconds.
+
+        The default value is (8 / 15.15): (default slowdown_steps / default runtime frequency).
         """
-        return 8
+        return (8 / 15.15)
 
 
 class CartesianPoseRobot(RobotInterface):


### PR DESCRIPTION
This PR is a continuation of MPD-2392. 

This is an update for the slowdown_steps parameter to return in seconds instead of steps. 
This way we ensure the stepsize won't change with the updated frequency in the runtime.

The sdk providers would still need to calculate their own slowdown time, based on how it is
implemented on our end. But the value is at least in SI units. 

The default value is set to be (8 / 15.15), where 8 is the default slowdown step length and 
15.15 is the default runtime frequency. There was no way to retrieve the runtime frequency
value as a parameter in the sdk; hence, it is set manually to 15.15.