### PR TITLE
Skip non-python files in the module loader

### DIFF
--- a/micropsi_integration_sdk/robot_interface_collection.py
+++ b/micropsi_integration_sdk/robot_interface_collection.py
@@ -73,12 +73,14 @@ class RobotInterfaceCollection:
             spec = importlib.util.spec_from_file_location(
                 name=module_id, location=str(filepath / '__init__.py'),
                 submodule_search_locations=[str(filepath)])
-        else:
+        elif filepath.suffix == ".py":
             spec = importlib.util.spec_from_file_location(name=module_id, location=str(filepath))
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        for _, obj in inspect.getmembers(module):
-            self.register_interface(obj)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            for _, obj in inspect.getmembers(module):
+                self.register_interface(obj)            
+        else:
+            logger.info("Skipping non-python file %s" % filepath)
 
     def load_interface_directory(self, path):
         """


### PR DESCRIPTION
Fail more gracefully if for some reason an interface directory contains a bunch of non-python files - like the gazebo-robot does 


## Before

```
[system.micropsi_integration_sdk] 2023-05-08 16:32:36 - MainThread:robot_interface_collection:register_interface() - INFO - Found SDK robot: Gazebo Cartesian Motion Robot
[system.micropsi_integration_sdk] 2023-05-08 16:32:36 - MainThread:robot_interface_collection:load_interface() - INFO - Searching /home/mpsi/micropsi_robots/robot_path/gazebo_keyboard.jpg for SDK robots.
[system.micropsi_integration_sdk] 2023-05-08 16:32:36 - MainThread:robot_interface_collection:load_interface_directory() - ERROR - 'NoneType' object has no attribute 'loader'
Traceback (most recent call last):
  File "/home/mpsi/src/micropsi2/.venv/lib/python3.6/site-packages/micropsi_integration_sdk/robot_interface_collection.py", line 93, in load_interface_directory
    self.load_interface(abspath)
  File "/home/mpsi/src/micropsi2/.venv/lib/python3.6/site-packages/micropsi_integration_sdk/robot_interface_collection.py", line 78, in load_interface
    module = importlib.util.module_from_spec(spec)
  File "<frozen importlib._bootstrap>", line 568, in module_from_spec
AttributeError: 'NoneType' object has no attribute 'loader'
[  system] 2023-05-08 16:32:36 - MainThread:mirai_api:_autoconfigure_cameras() - INFO - Registering GazeboCam device gz01.
```

## After
```
[system.micropsi_integration_sdk] 2023-05-08 16:33:42 - MainThread:robot_interface_collection:register_interface() - INFO - Found SDK robot: Gazebo Cartesian Motion Robot
[system.micropsi_integration_sdk] 2023-05-08 16:33:42 - MainThread:robot_interface_collection:load_interface() - INFO - Searching /home/mpsi/micropsi_robots/robot_path/gazebo_keyboard.jpg for SDK robots.
[system.micropsi_integration_sdk] 2023-05-08 16:33:42 - MainThread:robot_interface_collection:load_interface() - INFO - Skipping non-python file /home/mpsi/micropsi_robots/robot_path/gazebo_keyboard.jpg
[  system] 2023-05-08 16:33:42 - MainThread:mirai_api:_autoconfigure_cameras() - INFO - Registering GazeboCam device gz01.
```
