### PR TITLE
Fix: Actually do the import if it's a package not just a single file

### DIFF
--- a/micropsi_integration_sdk/robot_interface_collection.py
+++ b/micropsi_integration_sdk/robot_interface_collection.py
@@ -75,12 +75,14 @@ class RobotInterfaceCollection:
                 submodule_search_locations=[str(filepath)])
         elif filepath.suffix == ".py":
             spec = importlib.util.spec_from_file_location(name=module_id, location=str(filepath))
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            for _, obj in inspect.getmembers(module):
-                self.register_interface(obj)
         else:
             logger.info("Skipping non-python file %s" % filepath)
+
+        logger.info("Importing %s ", spec)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        for _, obj in inspect.getmembers(module):
+            self.register_interface(obj)
 
     def load_interface_directory(self, path):
         """


### PR DESCRIPTION
This undoes a bug I introduced here https://github.com/micropsi-industries/micropsi-integration-sdk/pull/13/files